### PR TITLE
Feature/custom normalizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 
+GREP ?=.
+
 build: components index.js
 	@component build --dev
 
@@ -7,7 +9,8 @@ components: component.json
 
 test:
 	@node_modules/.bin/mocha \
-		--reporter spec
+		--reporter spec \
+		--grep "$(GREP)"
 
 node_modules: package.json
 	@npm install

--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@
   objCase.find(obj, 'my.superCool.CLIMBING SHOES');  // 'x'
   ```
 
-### .del(obj, key)
+### .del(obj, key, val, [options])
 
   Deletes a nested key
 
@@ -34,7 +34,7 @@
   ```
 
 
-### .replace(obj, key)
+### .replace(obj, key, val, [options])
 
   Replaces a nested key
 

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ module.exports = module.exports.find = multiple(find);
  * Export the replacement function, return the modified object
  */
 
-module.exports.replace = function (obj, key, val) {
-  multiple(replace).apply(this, arguments);
+module.exports.replace = function (obj, key, val, options) {
+  multiple(replace).call(this, obj, key, val, options);
   return obj;
 };
 
@@ -23,8 +23,8 @@ module.exports.replace = function (obj, key, val) {
  * Export the delete function, return the modified object
  */
 
-module.exports.del = function (obj, key) {
-  multiple(del).apply(this, arguments);
+module.exports.del = function (obj, key, options) {
+  multiple(del).call(this, obj, key, null, options);
   return obj;
 };
 
@@ -34,7 +34,8 @@ module.exports.del = function (obj, key) {
  */
 
 function multiple (fn) {
-  return function (obj, path, val) {
+  return function (obj, path, val, options) {
+    normalize = options && isFunction(options.normalizer) ? options.normalizer : defaultNormalize;
     path = normalize(path);
 
     var key;
@@ -127,13 +128,24 @@ function replace (obj, key, val) {
 
 /**
  * Normalize a `dot.separated.path`.
- * 
+ *
  * A.HELL(!*&#(!)O_WOR   LD.bar => ahelloworldbar
  *
  * @param {String} path
  * @return {String}
  */
 
-function normalize(path) {
+function defaultNormalize(path) {
   return path.replace(/[^a-zA-Z0-9\.]+/g, '').toLowerCase();
+}
+
+/**
+ * Check if a value is a function.
+ *
+ * @param {*} val
+ * @return {boolean} Returns `true` if `val` is a function, otherwise `false`.
+ */
+
+function isFunction(val) {
+  return typeof val === 'function';
 }

--- a/test/test.js
+++ b/test/test.js
@@ -120,8 +120,21 @@ describe('obj-case', function () {
     it('should delete nested keys', function () {
       expect(objCase.del({ 'A bird' : { 'flew_under' : { 'theTrain' : 4 }}}, 'aBird.FLEW UNDER')).to.eql({ 'A bird': {} });
     });
-   });
 
+    it('should accept a custom key normalizer', function () {
+      var obj = { one: { a: { b: 'nested' } }, two: 'two' };
+      var normalize = function(path) {
+        return path.replace(/[x]/g, '');
+      };
+      var options = { normalizer: normalize };
+      var expected = {
+        one: { a: {} },
+        two: 'two'
+      };
+
+      expect(objCase.del(obj, 'xxonxe.xa.xxbxx', options)).to.eql(expected);
+    });
+  });
 
   describe('.replace()', function () {
     it('should replace simple keys', function () {
@@ -137,6 +150,20 @@ describe('obj-case', function () {
       expect(objCase.replace(obj, "Calvin.dog", 'the tedster')).to.eql({
         "Calvin" : { dog : 'the tedster' }
       });
+    });
+
+    it('should accept a custom key normalizer', function () {
+      var obj = { one: { a: { b: 'nested' } }, two: 'two' };
+      var normalize = function(path) {
+        return path.replace(/[x]/g, '');
+      };
+      var options = { normalizer: normalize };
+      var expected = {
+        one: { a: { b: 'newvalue' } },
+        two: 'two'
+      };
+
+      expect(objCase.replace(obj, 'xxonxe.xa.xxbxx', 'newvalue', options)).to.eql(expected);
     });
   });
 


### PR DESCRIPTION
Example use case (adapted from Mixpanel integration):

``` js
var traits = {
  '$created': 2014,
  'createdAt': 2014,
  'created_at': 2014,
  'created': 2014
};

// Doesn't strip out `$`
var normalize = function(path) {
  return path.replace(/[^A-Za-z0-9\.$]+/g, '').toLowerCase();
};

// Want to keep only dollar-prefixed version
['createdAt', 'created'].forEach(function(key) {
  objCase.del(traits, key, { normalizer: normalize });
});

// traits => { '$created': 2014 }
```
